### PR TITLE
Fix get-file

### DIFF
--- a/Core/scripts/cta-prod-get-file.py
+++ b/Core/scripts/cta-prod-get-file.py
@@ -37,16 +37,16 @@ def sigint_handler(signum, frame):
 
 def getfile(lfn):
     dirac = Dirac()
-    print('Start downloading ' + lfn)
+    print('Start downloading ' + lfn + '\n', end='')
     res = dirac.getFile(lfn, destDir=TEMPDIR)
 
     if not res['OK']:
-        print('Error downloading lfn:' + lfn)
+        print('Error downloading lfn:' + lfn + '\n', end='')
         return res['Message']
 
     name = os.path.basename(lfn)
     os.rename(os.path.join('.incomplete', name), name)
-    print('Successfully downloaded file:' + lfn)
+    print('Successfully downloaded file:' + lfn + '\n', end='')
 
 
 if __name__ == '__main__':

--- a/Core/scripts/cta-prod-get-file.py
+++ b/Core/scripts/cta-prod-get-file.py
@@ -21,9 +21,7 @@ Usage:
 
 Script.parseCommandLine(ignoreErrors=True)
 
-# It seems that this import must come after the script definition
-# or the import of the other Dirac packages.
-# The script was not working when this import came before.
+# the client import must come after parseCommandLine
 from DIRAC.Interfaces.API.Dirac import Dirac  # noqa
 
 TEMPDIR = '.incomplete'
@@ -90,5 +88,6 @@ if __name__ == '__main__':
         p.close()
         p.terminate()
     finally:
+        p.close()
         p.join()
         shutil.rmtree(TEMPDIR)

--- a/Core/scripts/cta-prod-get-file.py
+++ b/Core/scripts/cta-prod-get-file.py
@@ -7,7 +7,6 @@ __RCSID__ = "$Id$"
 from multiprocessing import Pool
 import signal
 import os
-import shutil
 
 # DIRAC imports
 from DIRAC.Core.Base import Script
@@ -90,4 +89,5 @@ if __name__ == '__main__':
     finally:
         p.close()
         p.join()
-        shutil.rmtree(TEMPDIR)
+        if len(os.listdir(TEMPDIR)) == 0:
+            os.rmdir(TEMPDIR)


### PR DESCRIPTION
Sorry, I did not test my previous PR properly and I didn't expect it to be merged so directly. Should have made clear, that it was still untested and a draft.

The first commit contains the fix (mainly the import order seems to be important with Dirac)

The second commit changes the script to move only fully downloaded files into the directory, and do the downloading in a `.incomplete` subdirectory.
